### PR TITLE
Fix import path

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"google.golang.org/grpc"
 	"io/ioutil"
-	"github.com/PassKit/passkit-golang-sdk/helpers/router"
+	"github.com/PassKit/passkit-golang-grpc-sdk/helpers/router"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"google.golang.org/grpc"
 	"io/ioutil"
-	"passkit-golang-sdk/helpers/router"
+	"github.com/PassKit/passkit-golang-sdk/helpers/router"
 )
 
 const (


### PR DESCRIPTION
Fix for `unrecognized import path "passkit-golang-sdk/helpers/router": import path does not begin with hostname
` error when doing `go get -u github.com/PassKit/passkit-golang-grpc-sdk`